### PR TITLE
Hide Hypothesis sidebar when printing; add dev setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ## Developer Setup
 
-1. Install [Bundler](https://bundler.io/)
+1. Install [Ruby](https://www.ruby-lang.org/en/)
 2. `bundle install`
 3. `bundle exec jekyll serve`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Grad ML
+
+## Developer Setup
+
+1. Install [Bundler](https://bundler.io/)
+2. `bundle install`
+3. `bundle exec jekyll serve`

--- a/_sass/print.scss
+++ b/_sass/print.scss
@@ -37,4 +37,8 @@
     max-width: none;
     margin-left: 0;
   }
+
+  hypothesis-sidebar {
+    display: none;
+  }
 }


### PR DESCRIPTION
This PR hides the hypothesis sidebar when printing. Note that with this PR, printing with the hypothesis sidebar open no longer works; I'm assuming people will not have a need to print with the hypothesis sidebar open.

This PR also adds instructions for running the site locally; however, I'm not familiar with Ruby, so I'm not actually sure if these instructions are correct...