### PR TITLE
increase font size for callout titles

### DIFF
--- a/_includes/css/callouts.scss.liquid
+++ b/_includes/css/callouts.scss.liquid
@@ -31,8 +31,8 @@ p.{{ callout[0] }}, blockquote.{{ callout[0] }} {
         content: "{{ callout[1].title }}";
         display: block;
         font-weight: bold;
-        text-transform: uppercase;
-        font-size: .75em;
+        /* text-transform: uppercase; */
+        /* font-size: .75em; */
         padding-bottom: .125rem;
     }
     {% endif %}
@@ -40,8 +40,8 @@ p.{{ callout[0] }}, blockquote.{{ callout[0] }} {
       color: ${{ callout[1].color }}-{{ callout_color_hue }};
       display: block;
       font-weight: bold;
-      text-transform: uppercase;
-      font-size: .75em;
+      /* text-transform: uppercase; */
+      /* font-size: .75em; */
       padding-bottom: .125rem;
     }
 }
@@ -58,8 +58,8 @@ p.{{ callout[0] }}-title, blockquote.{{ callout[0] }}-title {
       color: ${{ callout[1].color }}-{{ callout_color_hue }};
       display: block;
       font-weight: bold;
-      text-transform: uppercase;
-      font-size: .75em;
+      /* text-transform: uppercase; */
+      /* font-size: .75em; */
       padding-bottom: .125rem;
     }
 }


### PR DESCRIPTION
This PR increases the font size for all callout titles, making it easier to read theorem names.

Example:

<img width="1512" alt="image" src="https://github.com/shensquared/gradML/assets/7865976/929f28ad-9f83-476f-a977-8ae45ba1bbd8">

I also just realized that theorem titles aren't selectable since they're created using the `::before` pseudo element. If this turns out to be a deal-breaker, we can probably work around this issue with some Javascript.