### PR TITLE
Update some formatting (change <br> to blockquote; use newlines more liberally)

### DIFF
--- a/supervised/DiscriminativeGenerative.md
+++ b/supervised/DiscriminativeGenerative.md
@@ -177,27 +177,36 @@ is a Bernoulli distribution. The Naive Bayes classifier is defined by
 $$h(x) = \text{sign} (w^Tx+w_0)$$ for a suitable choice of $w$,$w_0$.
 
 {: .proof}
-Since $$X_j \in \{0,1\}$$, the Bernoulli distribution is
-<br>
-$$\begin{aligned}
+> Since $$X_j \in \{0,1\}$$, the Bernoulli distribution is
+> 
+> $$\begin{aligned}
 \mathbb{P}(X_j|Y=1) & = a_j^{X_j} (1-a_j)^{(1-X_j)} \\
 \mathbb{P}(X_j|Y=0) & = b_j^{X_j} (1-b_j)^{(1-X_j)}
-\end{aligned}$$ <br>where $a_j$ and $b_j$ are parameters for the $j$th
-dimension of $X$. With the conditional independence, we have 
-<br>
-$$\begin{aligned}
+\end{aligned}$$
+> 
+> where $a_j$ and $b_j$ are parameters for the $j$th
+> dimension of $X$. With the conditional independence, we have 
+> 
+> $$\begin{aligned}
 \mathbb{P}(Y=1|X)  & =\frac{\mathbb{P}(X|Y=1)\mathbb{P}(Y=1)}{\mathbb{P}(X|Y=1)\mathbb{P}(Y=1)+\mathbb{P}(X|Y=0)\mathbb{P}(Y=0)} \\
         & =\frac{1}{1+\frac{\mathbb{P}(X|Y=0)\mathbb{P}(Y=0)}{\mathbb{P}(X|Y=1)\mathbb{P}(Y=1)}} \\
         & = \frac{1}{1+\exp (- \log \frac{\mathbb{P}(X|Y=1)\mathbb{P}(Y=1)}{\mathbb{P}(X|Y=0)\mathbb{P}(Y=0)})} \\
         & =\sigma \left( \sum_j^d \log \frac{\mathbb{P}(X_j|Y=1)}{\mathbb{P}(X_j|Y=0)} + \log \frac{\mathbb{P}(Y=1)}{\mathbb{P}(Y=0)} \right)
 \end{aligned}$$ 
-<br>and therefore, <br>$$\begin{aligned}
+> 
+> and therefore,
+> 
+> $$\begin{aligned}
 \mathbb{P}(Y=1|X)  & = \sigma \left( \sum_j^d \log \frac{a_j^{X_j}(1-a_j)^{(1-X_j)}}{b_j^{X_j}(1-b_j)^{(1-X_j)}} + \log \frac{p}{1-p} \right) \\
         & = \sigma \left( \sum_j^d \left(X_j \log \frac{a_j(1-b_j)}{b_j(1-a_j)}\right) + \log \left(\frac{p}{1-p} \prod_j^d \frac{1-a_j}{1-b_j} \right) \right) \\
         & = \sigma \left( \sum_j^d w_j X_j  + w_0\right)
-\end{aligned}$$ <br>where $w_j = \log \frac{a_j(1-b_j)}{b_j(1-a_j)}$ and
-$w_0=\log \left(\frac{p}{1-p} \prod_j^d \frac{1-a_j}{1-b_j} \right)$.
-<br>Therefore, $$h(x) = \text{sign} (w^Tx+w_0)$$ and this shows the Naive Bayes is a linear classifier.
+\end{aligned}$$
+> 
+> where $w_j = \log \frac{a_j(1-b_j)}{b_j(1-a_j)}$ and
+> $w_0=\log \left(\frac{p}{1-p} \prod_j^d \frac{1-a_j}{1-b_j} \right)$.
+> 
+> Therefore, $$h(x) = \text{sign} (w^Tx+w_0)$$ and this shows the Naive Bayes is a linear classifier.
+
 # Naive Bayes vs. Logistic Regression
 
 We saw in the last section that Naive Bayes can be a linear classifier
@@ -262,16 +271,19 @@ challenging task and we will break our analysis into two parts
 For the first part, formally, we have the following theorem:
 
 {: .theorem}
-Let any $\epsilon_1$, $\delta >0$ and any $l \leq 0$
-be fixed. Assume that for some fixed $\rho_0 > 0$, we hvae
-$\rho_0 \leq \mathbb{P}(y=1) \leq 1- \rho_0$. Let
-$d = O ((1/\epsilon_1^2)\log(d/\delta))$, then with probability at least
-$1-\delta$:<br>
-$$\begin{aligned}
+> Let any $\epsilon_1$, $\delta >0$ and any $l \leq 0$
+> be fixed. Assume that for some fixed $\rho_0 > 0$, we hvae
+> $\rho_0 \leq \mathbb{P}(y=1) \leq 1- \rho_0$. Let
+> $d = O ((1/\epsilon_1^2)\log(d/\delta))$, then with probability at least
+> $1-\delta$:
+> 
+> $$\begin{aligned}
   |\hat{P}(X_j|Y=b) - \mathbb{P}(X_j|Y=b)| \leq \epsilon_1  
 \end{aligned}$$
-<br>
-and <br>$$\begin{aligned}
+> 
+> and
+> 
+> $$\begin{aligned}
   |\hat{P}(Y=b) - \mathbb{P}(Y=b)| \leq \epsilon_1
 \end{aligned}$$ for all $j=1,...,d$ and $b \in \mathcal{Y}$
 

--- a/supervised/classification_fundamentals.md
+++ b/supervised/classification_fundamentals.md
@@ -135,30 +135,34 @@ $h : \mathbb{R}^{d} \rightarrow\{0,1\}$, $L(h^*) \le L(h)$.
 
 
 {: .proof}
-Given $X=x$, the conditional error probability of any
-classifier $h$ may be written as: $$\begin{aligned}
+> Given $X=x$, the conditional error probability of any
+> classifier $h$ may be written as:
+> 
+> $$\begin{aligned}
 {\quad \mathbb{P}\left(h(X) \neq Y | X=x\right)} &{=1-\mathbb{P}\left(Y=h(X) | X=x\right)} \\
 & {=1-\left(\mathbb{P}\left(Y=1, h(X)=1 | X=x\right)+\mathbb{P}\left(Y=0, h(X)=0 | X=x\right)\right)} \\
 & =1-\left( [\![h(x)=1]\!] \mathbb{P}\left(Y=1 | X=x\right)+[\![h(x)=0]\!] \mathbb{P}\left(Y=0 | X=x\right)\right)\\
 & =1- \left([\![h(x)=1]\!] \eta(x)+ [\![h(x)=0]\!] (1-\eta(x))\right)
-\end{aligned}$$ where $\llbracket \cdot \rrbracket$ is the Iverson bracket, i.e. $\llbracket z \rrbracket=1$ if $z=$ 'true' and 0 if $z=$ 'false'. 
-<br>
-Thus, for every $x \in \mathbb{R}^d$, we have:
-<br>
-$$
+\end{aligned}$$
+> 
+> where $\llbracket \cdot \rrbracket$ is the Iverson bracket, i.e. $\llbracket z \rrbracket=1$ if $z=$ 'true' and 0 if $z=$ 'false'. 
+> 
+> Thus, for every $x \in \mathbb{R}^d$, we have:
+> 
+> $$
 \begin{aligned}
 & \mathbb{P}(h(X) \neq Y \mid X=x)-\mathbb{P}\left(h^*(X) \neq Y \mid X=x\right) \\
 & \quad=\eta(x)\left(\llbracket h^*(x)=1 \rrbracket-\llbracket h(x)=1 \rrbracket\right)+(1-\eta(x))\left(\llbracket h^*(x)=0 \rrbracket-\llbracket h(x)=0 \rrbracket\right)
 \end{aligned}
-$$
-<br>
-Since $$\llbracket h^*(x)=0 \rrbracket=1-\llbracket h^*(x)=1 \rrbracket$$, the above equals to $$(2 \eta(x)-1)\left(\llbracket h^*(x)=1 \rrbracket-\llbracket h(x)=1 \rrbracket\right)$$ which is non-negative based on the definition of 
-$$h^*\left(\eta(x)>1 / 2 \Leftrightarrow \llbracket h^*(x)=1 \rrbracket=1\right)$$. 
-<br>
-Thus we have
-$$
-\int \mathbb{P}(h(X) \neq Y \mid X=x) d \mathbb{P}(x) \geq \int \mathbb{P}\left(h^*(X) \neq Y \mid X=x\right) d \mathbb{P}(x)
-$$ or equivalently, $\mathbb{P}(h(X) \neq Y) \geq \mathbb{P}\left(h^*(X) \neq Y\right)$.
+> $$
+> 
+> Since $$\llbracket h^*(x)=0 \rrbracket=1-\llbracket h^*(x)=1 \rrbracket$$, the above equals to $$(2 \eta(x)-1)\left(\llbracket h^*(x)=1 \rrbracket-\llbracket h(x)=1 \rrbracket\right)$$ which is non-negative based on the definition of 
+> $$h^*\left(\eta(x)>1 / 2 \Leftrightarrow \llbracket h^*(x)=1 \rrbracket=1\right)$$. 
+> 
+> Thus we have
+> $$
+> \int \mathbb{P}(h(X) \neq Y \mid X=x) d \mathbb{P}(x) \geq \int \mathbb{P}\left(h^*(X) \neq Y \mid X=x\right) d \mathbb{P}(x)
+> $$ or equivalently, $\mathbb{P}(h(X) \neq Y) \geq \mathbb{P}\left(h^*(X) \neq Y\right)$.
 
 
 Related to the manipulations of
@@ -166,17 +170,17 @@ Theorem <a href="#thm:bayes" data-reference-type="ref"
 data-reference="thm:bayes">1</a> is a helpful exercise below:
 
 {: .exercise}
-Verify the following useful formula:
-<br>
-$$
-\begin{aligned}
-L^* & =\inf _{h: \mathbb{R}^d \rightarrow(0,1)} \mathbb{P}(h(X) \neq Y) \\
-& =\mathbb{E}[\min \{\eta(X), 1-\eta(X)\}] \\
-& =\frac{1}{2}-\frac{1}{2} \mathbb{E}[|2 \eta(X)-1|] .
-\end{aligned}
-$$
-<br>
-We call $L^*$ the Bayes Error (the minimum error possible any classifier; this is an idealized quantity)
+> Verify the following useful formula:
+> 
+> $$
+> \begin{aligned}
+> L^* & =\inf _{h: \mathbb{R}^d \rightarrow(0,1)} \mathbb{P}(h(X) \neq Y) \\
+> & =\mathbb{E}[\min \{\eta(X), 1-\eta(X)\}] \\
+> & =\frac{1}{2}-\frac{1}{2} \mathbb{E}[|2 \eta(X)-1|] .
+> \end{aligned}
+> $$
+> 
+> We call $L^*$ the Bayes Error (the minimum error possible any classifier; this is an idealized quantity)
 
 Per Theorem <a href="#thm:bayes" data-reference-type="ref"
 data-reference="thm:bayes">1</a>, we have found the best possible
@@ -247,14 +251,15 @@ That is, with large number of data points, even $1$-NN algorithm has
 risk that is within factor $2$ of the optimal risk.
 
 {: .proof}
-Given $X = x$, let $X'(n)$ the closest data point to $x$
-amongst given $n$ observations. Then due to
-$\mathcal{X} \subset \mathbb{R}^d$ (i.e. complete, separable metric
-space), it can be argued that $X'(n) \to x$ as $n\to \infty$ with
-probability $1$. Further, $\eta$ is continuous. Therefore,
-$\eta(X'(n)) \to \eta(x)$ as $n\to \infty$ with probability $1$. Let
-$Y'(n)$ be the label observed associated $X'(n)$. Then,
-$$\begin{aligned}
+> Given $X = x$, let $X'(n)$ the closest data point to $x$
+> amongst given $n$ observations. Then due to
+> $\mathcal{X} \subset \mathbb{R}^d$ (i.e. complete, separable metric
+> space), it can be argued that $X'(n) \to x$ as $n\to \infty$ with
+> probability $1$. Further, $\eta$ is continuous. Therefore,
+> $\eta(X'(n)) \to \eta(x)$ as $n\to \infty$ with probability $1$. Let
+> $Y'(n)$ be the label observed associated $X'(n)$. Then,
+>
+> $$\begin{aligned}
 \mathbb{P}(h_{1\text{-NN}}(x) \neq Y | X = x) & = \mathbb{P}(Y'(n) \neq Y | X = x)  \\
 & =  \mathbb{P}(Y'(n) = 1,  Y = 0| X = x) +  \mathbb{P}(Y'(n) = 0,  Y = 1| X = x) \\
 & \stackrel{(a)}{=}  \mathbb{P}(Y'(n) = 1 | X = x)  \mathbb{P}( Y = 0 | X = x) + \mathbb{P}(Y'(n) = 0 | X = x)  \mathbb{P}( Y = 1| X = x) \\
@@ -263,14 +268,14 @@ $$\begin{aligned}
 & \stackrel{(b)}{=} 2 \min\{\eta(x), 1-\eta(x)\} \max\{\eta(x), 1-\eta(x)\}  \\
 & \stackrel{(c)}{\leq} 2 \min\{\eta(x), 1-\eta(x)\}.
 \end{aligned}$$ 
-<br>
-In above, (a) follows from the fact that $Y'(n)$ and $Y$
-are generated independently per our generative model; (b) from that the
-fact for $\alpha, \beta \in \mathbb{R}$ we have
-$\alpha \beta = \min\{\alpha, \beta\} \max\{\alpha, \beta\}$; and (c)
-from the fact that $\eta(x) \in [0,1]$ as it is probability. Then, the
-claim of theorem follows by recalling that the Bayes risk
-$L^* = \mathbb{E}[\min\{\eta(X), 1-\eta(X)\}]$.
+> 
+> In above, (a) follows from the fact that $Y'(n)$ and $Y$
+> are generated independently per our generative model; (b) from that the
+> fact for $\alpha, \beta \in \mathbb{R}$ we have
+> $\alpha \beta = \min\{\alpha, \beta\} \max\{\alpha, \beta\}$; and (c)
+> from the fact that $\eta(x) \in [0,1]$ as it is probability. Then, the
+> claim of theorem follows by recalling that the Bayes risk
+> $L^* = \mathbb{E}[\min\{\eta(X), 1-\eta(X)\}]$.
 
 Theorem <a href="#thm:nn" data-reference-type="ref"
 data-reference="thm:nn">2</a> provides asymptotic guarantee for

--- a/supervised/learnability_and_vc.md
+++ b/supervised/learnability_and_vc.md
@@ -107,43 +107,49 @@ size $N$, every ERM hypothesis $h_S$ satisfies
 $L_\mathbb{P} \leq \epsilon.$
 
 {: .proof}
-Let $$\mathcal{H}_B$$ be the set of "failed" hypotheses, that is
-$$\mathcal{H}_B = \{ h \in \mathcal{H}: L_\mathbb{P}(h) > \epsilon\}.$$
-In addition, let $M$ be the set of misleading samples, that is
-$$M = \{ S : \exists h \in \mathcal{H}_B, L_S(h)=0 \}$$ Namely, for
-every $S \in M$, there is a ’failed’ hypothesis, $h \in \mathcal{B}$,
-that looks like a ’good’ hypothesis on $S$. <br><br>Now, recall that we would
-like to bound the probability of the event $L_\mathbb{P}(h_S)>\epsilon$.
-Since the realizability implies that $L_S(h_S)=0$, it follows that the
-event $$L_\mathbb{P}(h_S)>\epsilon$$ can only happen if for some
-$$h\in \mathcal{H}_B$$, we have $L_S(h) =0$.<br><br>
-In other words, the failure
-will only happen if our training data is in the set of misleading
-samples Set $M$. Formally, we have
-$$\{S : L_{\mathbb{P}}(h_S)>\epsilon\} \subseteq M$$ As we can write $M$
-as $$M = \cup_{h \in \mathcal{H}_B}\{S : L_{S}(h)=0\}$$ Hence,
-$${P}\left( \{ S: L_\mathbb{P} (h_{S}) > \epsilon \}\right) \leq {P}\left( \cup_{h \in \mathcal{H}_B}\{S : L_{S}(h)=0\}\right)$$
-Applying the union bound to the right-hand side yields
-$${P}\left( \{ S: L_\mathbb{P} (h_{S})\right)  \leq \sum_{h \in \mathcal{H}_B} {P} \left(\{S : L_{S}(h)=0\}\ \right)$$
-Next, we can bound each summand of the right-hand side. Fix some
-’failed’ hypothesis $$h \in \mathcal{H}_B$$, the event $L_S(h) =0$ is
-equivalent to the event that in the training set, $\forall i$,
-$h(x_i)=y_i$. Since the training data are i.i.d. sampled, we have
-$${P} \left(\{S : L_{S}(h)=0\}\ \right) = \prod_{i=1}^N {P} \left( \{x_i: h(x_i) = y_i\} \right)$$
-For each individual sampling of an element of the training set, we have
-$${P} \left( \{x_i: h(x_i) = y_i\} \right) = 1-L_{\mathbb{P}}(h) \leq 1-\epsilon$$
-where the last inequality follows from the fact that
-$$h \in \mathcal{H}_B$$.<br><br>Using the inequality
-$1-\epsilon \leq e^{-\epsilon}$, we have for every
-$$h \in \mathcal{H}_B$$,
-$$P\left( S: L_{S}(h) = 0\right) \leq (1-\epsilon)^N \leq e^{-\epsilon N}$$
-Therefore, we have
-$$P\left( S: L_{\mathbb{P}}(h_S) > \epsilon \right) \leq |\mathcal{H}_B| e^{-\epsilon N} \leq |\mathcal{H}|e^{-\epsilon N}$$
-Let $\delta = P\left( S: L_{\mathbb{P}}(h_S) > \epsilon \right)$, we
-will reach the desired conclusion that with probability at least
-$1-\delta$, and having
-$N \geq \frac{\log (|\mathcal{H}|/\delta)}{\epsilon}$,
-$$L_{\mathbb{P}}(h_S) \leq \epsilon.$$
+> Let $$\mathcal{H}_B$$ be the set of "failed" hypotheses, that is
+> $$\mathcal{H}_B = \{ h \in \mathcal{H}: L_\mathbb{P}(h) > \epsilon\}.$$
+> In addition, let $M$ be the set of misleading samples, that is
+> $$M = \{ S : \exists h \in \mathcal{H}_B, L_S(h)=0 \}$$ Namely, for
+> every $S \in M$, there is a ’failed’ hypothesis, $h \in \mathcal{B}$,
+> that looks like a ’good’ hypothesis on $S$.
+> 
+> Now, recall that we would
+> like to bound the probability of the event $L_\mathbb{P}(h_S)>\epsilon$.
+> Since the realizability implies that $L_S(h_S)=0$, it follows that the
+> event $$L_\mathbb{P}(h_S)>\epsilon$$ can only happen if for some
+> $$h\in \mathcal{H}_B$$, we have $L_S(h) =0$.
+> 
+> In other words, the failure
+> will only happen if our training data is in the set of misleading
+> samples Set $M$. Formally, we have
+> $$\{S : L_{\mathbb{P}}(h_S)>\epsilon\} \subseteq M$$ As we can write $M$
+> as $$M = \cup_{h \in \mathcal{H}_B}\{S : L_{S}(h)=0\}$$ Hence,
+> $${P}\left( \{ S: L_\mathbb{P} (h_{S}) > \epsilon \}\right) \leq {P}\left( \cup_{h \in \mathcal{H}_B}\{S : L_{S}(h)=0\}\right)$$
+> Applying the union bound to the right-hand side yields
+> $${P}\left( \{ S: L_\mathbb{P} (h_{S})\right)  \leq \sum_{h \in \mathcal{H}_B} {P} \left(\{S : L_{S}(h)=0\}\ \right)$$
+> Next, we can bound each summand of the right-hand side. Fix some
+> ’failed’ hypothesis $$h \in \mathcal{H}_B$$, the event $L_S(h) =0$ is
+> equivalent to the event that in the training set, $\forall i$,
+> $h(x_i)=y_i$. Since the training data are i.i.d. sampled, we have
+> $${P} \left(\{S : L_{S}(h)=0\}\ \right) = \prod_{i=1}^N {P} \left( \{x_i: h(x_i) = y_i\} \right)$$
+> For each individual sampling of an element of the training set, we have
+> $${P} \left( \{x_i: h(x_i) = y_i\} \right) = 1-L_{\mathbb{P}}(h) \leq 1-\epsilon$$
+> where the last inequality follows from the fact that
+> $$h \in \mathcal{H}_B$$.
+> 
+> Using the inequality
+> $1-\epsilon \leq e^{-\epsilon}$, we have for every
+> $$h \in \mathcal{H}_B$$,
+> $$P\left( S: L_{S}(h) = 0\right) \leq (1-\epsilon)^N \leq e^{-\epsilon N}$$
+>
+> Therefore, we have
+> $$P\left( S: L_{\mathbb{P}}(h_S) > \epsilon \right) \leq |\mathcal{H}_B| e^{-\epsilon N} \leq |\mathcal{H}|e^{-\epsilon N}$$
+> Let $\delta = P\left( S: L_{\mathbb{P}}(h_S) > \epsilon \right)$, we
+> will reach the desired conclusion that with probability at least
+> $1-\delta$, and having
+> $N \geq \frac{\log (|\mathcal{H}|/\delta)}{\epsilon}$,
+> $$L_{\mathbb{P}}(h_S) \leq \epsilon.$$
 
 A weaker result can be proved without realizability, see Exercise 2 for
 details.
@@ -420,26 +426,19 @@ understand the meaning of the lower and upper bound of VC-Dimension.
 # Fundamental Theorem of Learnability
 As the name suggests, a pretty important theorem:
 
-<p id="fundamental" class="theorem">
-(The Fundamental Theorem of Statistical Learning). Let
-$\mathcal{H}$ be a hypothesis class of functions from a domain
-$\mathcal{X}$ to $\{0, 1\}$ and let the loss function be the $0 - 1$
-loss. Then the following are equivalent:
-<br>
-1. $\mathcal{H}$ has the uniform convergence property.
-<br>
-2. Any ERM rule is a successful agnostic PAC learner for
-    $\mathcal{H}$.
-<br>
-3. $\mathcal{H}$ is agnostic PAC learnable.
-<br>
-4. $\mathcal{H}$ is PAC learnable.
-<br>
-5. $\mathcal{H}$ Any ERM rule is a successful PAC learner for
-    $\mathcal{H}$.
-<br>
-6. $\mathcal{H}$ has a finite VC-dimension.
-</p>
+{: .theorem #fundamental theorem-name="The Fundamental Theorem of Statistical Learning" }
+> Let $\mathcal{H}$ be a hypothesis class of functions from a domain
+> $\mathcal{X}$ to $\{0, 1\}$ and let the loss function be the $0 - 1$
+> loss. Then the following are equivalent:
+> 
+> 1. $\mathcal{H}$ has the uniform convergence property.
+> 2. Any ERM rule is a successful agnostic PAC learner for
+>     $\mathcal{H}$.
+> 3. $\mathcal{H}$ is agnostic PAC learnable.
+> 4. $\mathcal{H}$ is PAC learnable.
+> 5. $\mathcal{H}$ Any ERM rule is a successful PAC learner for
+>     $\mathcal{H}$.
+> 6. $\mathcal{H}$ has a finite VC-dimension.
 
 In our previous discussion, we saw $1 \to 2$. $2 \to 3$, $3 \to 4$ and
 $2 \to 5$ are all trivial. For $4 \to 6$ and $5 \to 6$, there is
@@ -495,13 +494,13 @@ shattered by $\mathcal{H}$, then $|\mathcal{H}_C|$ is upper-bounded by
 the cardinality of $\mathcal{C}$. Then we can show the ERM error is
 bounded using the growth function.
 
-<p class="theorem">
-Let $\mathcal{H}$ be a class and $\tau_{\mathcal{H}}$
-its growth function. Then for every distribution $\mathbb{P}(X,Y)$ and
-every $\delta \in (0, 1)$, with probability at least $1-\delta$ over the
-choices of $S \sim \mathbb{P}$, we have
-$$|L_S(h) - L_\mathbb{P}(h) | \leq \frac{4+\sqrt{\log \tau_{\mathcal{H}}(2N)}}{\delta \sqrt{2N}}$$
-</p>
+{: .theorem}
+> Let $\mathcal{H}$ be a class and $\tau_{\mathcal{H}}$
+> its growth function. Then for every distribution $\mathbb{P}(X,Y)$ and
+> every $\delta \in (0, 1)$, with probability at least $1-\delta$ over the
+> choices of $S \sim \mathbb{P}$, we have
+> 
+> $$|L_S(h) - L_\mathbb{P}(h) | \leq \frac{4+\sqrt{\log \tau_{\mathcal{H}}(2N)}}{\delta \sqrt{2N}}$$
 
 And it follows from here that if VC-Dim($\mathcal{H}$) is finite, then
 the uniform convergence property holds, and indeed,
@@ -511,20 +510,18 @@ suffices for the uniform convergence property to hold.
 A more quantitative version of this theorem is as follows, and the proof
 can be found in Chapter 28 of \[SSS\].
 
-<p class="theorem">
-
-*Let $\mathcal{H}$ be a hypothesis class of functions
-from a domain $\mathcal{X}$ to $\{0, 1\}$ and let the loss function be
-the $0 -1$ loss. Assume that $VC-Dim(\mathcal{H}) =d < \infty$. Then,
-there are absolute constants $C_1$, $C_2$ such that:*
-
-1. $\mathcal{H}$ has the uniform convergence property with sample
-    complexity
-    $$C_1\frac{d+\log(1/\delta)}{\epsilon^2} \leq N_\mathcal{H}^{UC}(\epsilon,\delta) \leq C_2 \frac{d+\log(1/\delta)}{\epsilon^2}$$
-
-2. $\mathcal{H}$ is agnostic PAC learnable with sample complexity
-    $$C_1\frac{d+\log(1/\delta)}{\epsilon^2} \leq N_\mathcal{H}(\epsilon,\delta) \leq C_2 \frac{d+\log(1/\delta)}{\epsilon^2}$$
-
-3. *$\mathcal{H}$ is PAC learnable with sample complexity
+{: .theorem}
+> Let $\mathcal{H}$ be a hypothesis class of functions
+> from a domain $\mathcal{X}$ to $\{0, 1\}$ and let the loss function be
+> the $0 -1$ loss. Assume that $VC-Dim(\mathcal{H}) =d < \infty$. Then,
+> there are absolute constants $C_1$, $C_2$ such that:
+> 
+> 1. $\mathcal{H}$ has the uniform convergence property with sample
+>     complexity
+>     $$C_1\frac{d+\log(1/\delta)}{\epsilon^2} \leq N_\mathcal{H}^{UC}(\epsilon,\delta) \leq C_2 \frac{d+\log(1/\delta)}{\epsilon^2}$$
+> 
+> 2. $\mathcal{H}$ is agnostic PAC learnable with sample complexity
+>     $$C_1\frac{d+\log(1/\delta)}{\epsilon^2} \leq N_\mathcal{H}(\epsilon,\delta) \leq C_2 \frac{d+\log(1/\delta)}{\epsilon^2}$$
+> 
+> 3. *$\mathcal{H}$ is PAC learnable with sample complexity
     $$C_1\frac{d+\log(1/\delta)}{\epsilon} \leq N_\mathcal{H}(\epsilon,\delta) \leq C_2 \frac{d\log (1/\epsilon)+\log(1/\delta)}{\epsilon}$$
-</p>

--- a/supervised/regularization.md
+++ b/supervised/regularization.md
@@ -90,7 +90,10 @@ how the average value of $\hat{f}$ differs from the true $f$. The term
 $\mathbb{E}[(\hat{f}-\mathbb{E}\hat{f})^2]$ is a variance term, as it
 quantifies how $\hat{f}$ differs from the average value of $\hat{f}$.
 
-We prove now the bias-variance tradeoff equality. $$\begin{aligned}
+We prove now the bias-variance tradeoff equality.
+
+$$
+\begin{aligned}
 \mathbb{E}[(y-\hat{f})^2]
 &= \mathbb{E}[(y-f+f-\hat{f})^2]&\\
 &= \mathbb{E}[(y-f)^2]+\mathbb{E}[(f-\hat{f})^2]+2\mathbb{E}[(y-f)(f-\hat{f})]&\\
@@ -99,7 +102,8 @@ We prove now the bias-variance tradeoff equality. $$\begin{aligned}
 &= \mathbb{E}[\eta^2] + \mathbb{E}[(f - \mathbb{E}\hat{f} + \mathbb{E}\hat{f} - \hat{f})^2]&\\
 &= \mathbb{E}[\eta^2] + \mathbb{E}[(f - \mathbb{E}\hat{f})^2] + \mathbb{E}[(\mathbb{E}\hat{f} - \hat{f})^2] + 2 (f - \mathbb{E}\hat{f})^T \mathbb{E}[\mathbb{E}\hat{f} - \hat{f}]&\\
 &= \mathbb{E}[\eta^2] + \mathbb{E}[(f - \mathbb{E}\hat{f})^2] + \mathbb{E}[(\mathbb{E}\hat{f} - \hat{f})^2] & [\text{uses } \mathbb{E}[\mathbb{E}\hat{f} - \hat{f}] = 0]
-\end{aligned}$$
+\end{aligned}
+$$
 
 We can now look at linear regression from the perspective of the
 bias-variance tradeoff. Theorem
@@ -108,13 +112,10 @@ data-reference="thm:gaussmarkov">1</a> shows that linear regression
 achieves the smallest expected error among all unbiased linear
 estimator.
 
-<div id="thm:gaussmarkov" class="theorem">
-
-**The Gauss-Markov Theorem**: *The linear least-squares
+{: .theorem #thm:gaussmarkov theorem-name="The Gauss-Markov Theorem"}
+The linear least-squares
 estimator is the best unbiased linear estimator (i.e. the lowest
-variance estimator among linear estimators).*
-
-</div>
+variance estimator among linear estimators).
 
 This theorem leaves open the possibility of achieving smaller expected
 error with linear estimators, as long as they are biased. Such
@@ -197,7 +198,9 @@ $y \in \mathbb{R}^N$, $\epsilon \in \mathbb{R}^N$. Note that the noise
 can be correlated. Let $z = \mathbb{E}[y]$ and
 $\hat{z} = K(K+N\lambda I)^{-1}y$. Note that $\hat{z}$ is the prediction
 made on these points using the kernelized least-squares estimator. Then
-the expected error minus the noise component is: $$\begin{aligned}
+the expected error minus the noise component is:
+
+$$\begin{aligned}
 \frac{1}{N}\mathbb{E}[||z-\hat{z}||^2]
 &= \frac{1}{N}\mathbb{E}[||z-\mathbb{E}\hat{z}||^2] + \frac{1}{N} \mathbb{E}[||\mathbb{E}\hat{z} - \hat{z}||^2] + \frac{1}{N} (z-\mathbb{E}\hat{z})^T\mathbb{E}[\mathbb{E}\hat{z} - \hat{z}]\\
 &= \frac{1}{N}\mathbb{E}[||z-\mathbb{E}\hat{z}||^2] + \frac{1}{N} \mathbb{E}[||\mathbb{E}\hat{z} - \hat{z}||^2]\\
@@ -207,7 +210,9 @@ the expected error minus the noise component is: $$\begin{aligned}
 &\qquad + \frac{1}{N} \operatorname{trace}[(K(K+N\lambda I)^{-1}) \operatorname{var}(y) (K(K+N\lambda I)^{-1})^T]\\
 &= \frac{1}{N} ||N\lambda (K+N\lambda I)^{-1}z||^2 + \frac{1}{N} \operatorname{trace} [C (K+N\lambda I)^{-1}K^2(K+N\lambda I)^{-1}]\\
 &= N \lambda^2 z^T (K+N\lambda I)^{-2} z + \frac{1}{N} \operatorname{trace} [C (K+N\lambda I)^{-1}K^2(K+N\lambda I)^{-1}]
-\end{aligned}$$ Then the bias is
+\end{aligned}$$
+
+Then the bias is
 $$N \lambda^2 z^T (K+N\lambda I)^{-2} z$$ and the variance is
 $$\frac{1}{N} \operatorname{trace}[C (K+N\lambda I)^{-1}K^2(K+N\lambda I)^{-1}].$$
 


### PR DESCRIPTION
This PR changes multiline theorems to use blockquotes rather than using `<br>` repeatedly. Note that this changes how the content of the theorem is displayed:

Before:

<img width="1505" alt="image" src="https://github.com/shensquared/gradML/assets/7865976/54e898ae-93f5-4a5a-9c21-8e48a08c7ed2">

After:

<img width="1505" alt="image" src="https://github.com/shensquared/gradML/assets/7865976/487b861f-295e-429d-96f3-2bff64399fa8">

This PR also changes some other sections to use newlines and block latex elements more liberally. I'm assuming we prefer using centered block latex elements with more padding than inline latex elements with less padding, but if that's not the case, please let me know!