### PR TITLE
Support searching for theorems

### DIFF
--- a/assets/js/zzzz-search-data.json
+++ b/assets/js/zzzz-search-data.json
@@ -68,6 +68,33 @@ permalink: /assets/js/search-data.json
   }
         {%- assign i = i | plus: 1 -%}
       {%- endunless -%}
+
+      {% comment %}
+        This section enables searching for theorems in the exact form
+        <p|blockquote class="theorem" id="theorem-id" theorem-name="theorem-name">theorem-content</p|blockquote>
+        Note that the content is a bit buggy for multi-line theorems...
+      {% endcomment %}
+      {%- assign page_content = page_content | replace: '<blockquote ', '<p ' | replace: '</blockquote>', '</p>' -%}
+      {%- assign parts = page_content | split: '<p class="theorem" id="' -%}
+      {%- for part in parts offset: 1 -%}
+        {%- assign theorem_part = part | split: '</p>' | first -%}
+        {%- assign theorem_id = part | split: '"' | first -%}
+        {%- assign theorem_name_tmp = part | split: 'theorem-name="' -%}
+        {%- assign theorem_name = theorem_name_tmp[1] | split: '"' | first -%}
+        {%- assign theorem_content_tmp = theorem_part | split: '">' -%}
+        {%- assign theorem_content = theorem_content_tmp[1] | strip_html -%}
+        {%- assign theorem_url = page.url | split: '#' | first -%}
+        {%- assign theorem_url = theorem_url | append: '#' | append: theorem_id -%}
+  {%- unless i == 0 -%},{%- endunless -%}
+  "{{ i }}": {
+    "doc": {{ page.title | jsonify }},
+    "title": {{ 'Theorem: ' | append: theorem_name | jsonify }},
+    "content": {{ theorem_content | replace: '</h', ' . </h' | replace: '<hr', ' . <hr' | replace: '</p', ' . </p' | replace: '<ul', ' . <ul' | replace: '</ul', ' . </ul' | replace: '<ol', ' . <ol' | replace: '</ol', ' . </ol' | replace: '</tr', ' . </tr' | replace: '<li', ' | <li' | replace: '</li', ' | </li' | replace: '</td', ' | </td' | replace: '<td', ' | <td' | replace: '</th', ' | </th' | replace: '<th', ' | <th' | strip_html | remove: 'Table of contents' | normalize_whitespace | replace: '. . .', '.' | replace: '. .', '.' | replace: '| |', '|' | append: ' ' | jsonify }},
+    "url": "{{ theorem_url | relative_url }}",
+    "relUrl": "{{ theorem_url }}"
+  }
+        {%- assign i = i | plus: 1 -%}
+      {%- endfor -%}
     {%- endif -%}
   {%- endfor -%}
 {%- endfor %}

--- a/supervised/classification_fundamentals.md
+++ b/supervised/classification_fundamentals.md
@@ -129,7 +129,7 @@ any other classifier in terms of minimizing the risk, as established
 formally via the following theorem (stated formally for
 $\mathcal{X}=\mathbb{R}^d$ for simplicity).
 
-{: .theorem theorem-name="BC Optimality"}
+{: .theorem #thm:bc-optimality theorem-name="BC Optimality"}
 For any classifier
 $h : \mathbb{R}^{d} \rightarrow\{0,1\}$, $L(h^*) \le L(h)$.
 


### PR DESCRIPTION
This PR lets users search for theorems by name. Searchable theorems are required to have a class of ".theorem", an ID, and a theorem name, in that order (ie. `{: .theorem #thm:my-theorem-id theorem-name="my theorem name" }`)

<img width="1505" alt="image" src="https://github.com/shensquared/gradML/assets/7865976/9e327b26-cc68-4532-ad0d-5dd0299026f9">

Unfortunately, I'm not familiar with Liquid, so the code is quite messy...